### PR TITLE
(GH-1244) Serialize plan variables as pcore 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,3 +95,7 @@ Lint/SuppressedException:
 # Enforce LF line endings, even when on Windows
 Layout/EndOfLine:
   EnforcedStyle: lf
+
+Lint/AmbiguousOperator:
+  Exclude:
+    - lib/bolt/apply_target.rb

--- a/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_target.rb
@@ -4,10 +4,9 @@ require 'bolt/error'
 
 # Get a single target from inventory if it exists, otherwise create a new Target.
 #
-# **NOTE:** Calling `get_target` inside an `apply` block with a
-# version 2 inventory creates a new Target object.
-# `get_target('all')` returns an empty array.
+# **NOTE:** Calling `get_target('all')` returns an empty array.
 # **NOTE:** Only compatible with inventory v2
+# **NOTE:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_target) do
   # @param name A Target name.
   # @return A single target, either new or from inventory.
@@ -22,6 +21,11 @@ Puppet::Functions.create_function(:get_target) do
 
   def get_target(name)
     inventory = Puppet.lookup(:bolt_inventory)
+    if inventory == 'apply'
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'get_target')
+    end
+
     # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call(self.class.name)

--- a/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
+++ b/bolt-modules/boltlib/lib/puppet/functions/get_targets.rb
@@ -3,10 +3,9 @@
 require 'bolt/error'
 
 # Parses common ways of referring to targets and returns an array of Targets.
-#
-# **NOTE:** Calling `get_targets` inside an `apply` block with a
-# version 2 inventory creates a new Target object.
 # `get_targets('all')` returns an empty array.
+#
+# **NOTE:** Not available in apply block when `future` is true
 Puppet::Functions.create_function(:get_targets) do
   # @param names A pattern or array of patterns identifying a set of targets.
   # @return A list of unique Targets resolved from any target URIs and groups.
@@ -27,6 +26,11 @@ Puppet::Functions.create_function(:get_targets) do
 
   def get_targets(names)
     inventory = Puppet.lookup(:bolt_inventory)
+    if inventory == 'apply'
+      raise Puppet::ParseErrorWithIssue
+        .from_issue_and_stack(Bolt::PAL::Issues::PLAN_OPERATION_NOT_SUPPORTED_WHEN_COMPILING, action: 'get_targets')
+    end
+
     # Bolt executor not expected when invoked from apply block
     executor = Puppet.lookup(:bolt_executor) { nil }
     executor&.report_function_call(self.class.name)

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -8,6 +8,7 @@ require 'open3'
 require 'bolt/error'
 require 'bolt/task'
 require 'bolt/apply_result'
+require 'bolt/apply_target'
 require 'bolt/util/puppet_log_level'
 
 module Bolt
@@ -129,6 +130,49 @@ module Bolt
       JSON.parse(out)
     end
 
+    def future_compile(target, catalog_input)
+      trusted = Puppet::Context::TrustedInformation.new('local', target.name, {})
+      catalog_input[:target] = {
+        name: target.name,
+        facts: @inventory.facts(target).merge('bolt' => true),
+        vars: @inventory.vars(target),
+        trusted: trusted.to_h
+      }
+      # rubocop:disable Style/GlobalVars
+      catalog_input[:future] = $future
+      # rubocop:enable Style/GlobalVars
+
+      bolt_catalog_exe = File.join(libexec, 'bolt_catalog')
+      old_path = ENV['PATH']
+      ENV['PATH'] = "#{RbConfig::CONFIG['bindir']}#{File::PATH_SEPARATOR}#{old_path}"
+      out, err, stat = Open3.capture3('ruby', bolt_catalog_exe, 'compile', stdin_data: catalog_input.to_json)
+      ENV['PATH'] = old_path
+
+      # stderr may contain formatted logs from Puppet's logger or other errors.
+      # Print them in order, but handle them separately. Anything not a formatted log is assumed
+      # to be an error message.
+      logs = err.lines.map do |l|
+        begin
+          JSON.parse(l)
+        rescue StandardError
+          l
+        end
+      end
+      logs.each do |log|
+        if log.is_a?(String)
+          @logger.error(log.chomp)
+        else
+          log.map { |k, v| [k.to_sym, v] }.each do |level, msg|
+            bolt_level = Bolt::Util::PuppetLogLevel::MAPPING[level]
+            @logger.send(bolt_level, "#{target.name}: #{msg.chomp}")
+          end
+        end
+      end
+
+      raise(ApplyError, target.name) unless stat.success?
+      JSON.parse(out)
+    end
+
     def validate_hiera_config(hiera_config)
       if File.exist?(File.path(hiera_config))
         data = File.open(File.path(hiera_config), "r:UTF-8") { |f| YAML.safe_load(f.read, [Symbol]) }
@@ -155,13 +199,20 @@ module Bolt
         options = args[1].map { |k, v| [k.sub(/^_/, '').to_sym, v] }.to_h
       end
 
-      # collect plan vars and merge them over target vars
       plan_vars = scope.to_hash(true, true)
       %w[trusted server_facts facts].each { |k| plan_vars.delete(k) }
 
       targets = @inventory.get_targets(args[0])
 
-      apply_ast(apply_body, targets, options, plan_vars)
+      # rubocop:disable Style/GlobalVars
+      if $future
+        Puppet.override(bolt_inventory: 'apply') do
+          apply_ast(apply_body, targets, options, plan_vars)
+        end
+      else
+        apply_ast(apply_body, targets, options, plan_vars)
+      end
+      # rubocop:enable Style/GlobalVars
     end
 
     # Count the number of top-level statements in the AST.
@@ -179,11 +230,64 @@ module Bolt
     def apply_ast(raw_ast, targets, options, plan_vars = {})
       ast = Puppet::Pops::Serialization::ToDataConverter.convert(raw_ast, rich_data: true, symbol_to_string: true)
 
+      # rubocop:disable Style/GlobalVars
+      if $future
+        %w[result resultset applyresult].each do |type|
+          Puppet.lookup(:loaders).private_environment_loader.load(:type, type)
+        end
+        # Collect target options to be serialized to the catalog for
+        # ApplyTarget to pick up
+        target_vars = plan_vars.select { |_, var| var.is_a?(Bolt::Target2) } || {}
+
+        target_opts = target_vars.transform_values do |v|
+          v.to_h.select do |k|
+            Bolt::ApplyTarget::COMPUTED.map(&:to_s).include?(k)
+          end
+        end
+
+        result_vars = plan_vars.select { |_, var| var.is_a?(Bolt::Result) }
+        result_vars.transform_values! do |v|
+          v.target.to_h.select do |k|
+            Bolt::ApplyTarget::COMPUTED.map(&:to_s).include?(k)
+          end
+        end
+        target_opts.merge!(result_vars)
+
+        result_set_vars = plan_vars.select { |_, var| var.is_a?(Bolt::ResultSet) }
+        result_set_vars.transform_values! do |v|
+          v.targets.each_with_object({}) do |target, acc|
+            acc[target.name] = target.to_h.select do |k|
+              Bolt::ApplyTarget::COMPUTED.map(&:to_s).include?(k)
+            end
+          end
+        end
+        target_opts.merge!(result_set_vars)
+        # target_opts = { varname => { protocol => 'ssh' }, resultset => { targetname => { protocol => 'ssh' }}}
+
+        # Serialize as pcore for *Result* objects
+        plan_vars = Puppet::Pops::Serialization::ToDataConverter.convert(plan_vars,
+                                                                         rich_data: true,
+                                                                         symbol_as_string: true,
+                                                                         type_by_reference: true,
+                                                                         local_reference: false)
+        scope = {
+          code_ast: ast,
+          modulepath: @modulepath,
+          pdb_config: @pdb_client.config.to_hash,
+          hiera_config: @hiera_config,
+          plan_vars: plan_vars,
+          target_opts: target_opts
+        }
+      end
+      # rubocop:enable Style/GlobalVars
+
       r = @executor.log_action('apply catalog', targets) do
         futures = targets.map do |target|
           Concurrent::Future.execute(executor: @pool) do
             @executor.with_node_logging("Compiling manifest block", [target]) do
-              compile(target, ast, plan_vars)
+              # rubocop:disable Style/GlobalVars
+              $future ? future_compile(target, scope) : compile(target, ast, plan_vars)
+              # rubocop:enable Style/GlobalVars
             end
           end
         end

--- a/lib/bolt/apply_result.rb
+++ b/lib/bolt/apply_result.rb
@@ -85,6 +85,19 @@ module Bolt
       end
     end
 
+    def self._pcore_init_from_hash(init_hash); end
+
+    def _pcore_init_from_hash(init_hash)
+      opts = init_hash.reject { |k, _| k == 'target' }
+      initialize(init_hash['target'], opts.transform_keys(&:to_sym))
+    end
+
+    def _pcore_init_hash
+      { 'target' => @target,
+        'error' => value['_error'],
+        'report' => value['report'] }
+    end
+
     def initialize(target, error: nil, report: nil)
       @target = target
       @value = {}

--- a/lib/bolt/apply_target.rb
+++ b/lib/bolt/apply_target.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Bolt
+  class ApplyTarget
+    ATTRIBUTES ||= %i[uri name target_alias config vars facts features
+                      plugin_hooks safe_name].freeze
+    COMPUTED ||= %i[host password port protocol user].freeze
+
+    attr_reader *ATTRIBUTES
+    attr_accessor *COMPUTED
+
+    def self._pcore_init_from_hash(init_hash); end
+
+    def _pcore_init_from_hash(init_hash)
+      initialize(init_hash)
+    end
+
+    def initialize(target_hash)
+      keys = ATTRIBUTES + COMPUTED
+      keys.each do |attr|
+        instance_variable_set("@#{attr}", target_hash[attr.to_s])
+      end
+    end
+  end
+end

--- a/lib/bolt/result.rb
+++ b/lib/bolt/result.rb
@@ -73,6 +73,22 @@ module Bolt
       new(target, value: value)
     end
 
+    def self._pcore_init_from_hash(init_hash); end
+
+    def _pcore_init_from_hash(init_hash)
+      opts = init_hash.reject { |k, _v| k == 'target' }
+      initialize(init_hash['target'], opts.transform_keys(&:to_sym))
+    end
+
+    def _pcore_init_hash
+      { 'target' => @target,
+        'error' => @value['_error'],
+        'message' => @value['_output'],
+        'value' => @value,
+        'action' => @action,
+        'object' => @object }
+    end
+
     def initialize(target, error: nil, message: nil, value: nil, action: nil, object: nil)
       @target = target
       @value = value || {}

--- a/lib/bolt/result_set.rb
+++ b/lib/bolt/result_set.rb
@@ -12,6 +12,16 @@ module Bolt
       include(Puppet::Pops::Types::IteratorProducer)
     end
 
+    def self._pcore_init_from_hash(init_hash); end
+
+    def _pcore_init_from_hash(init_hash)
+      initialize(init_hash['results'])
+    end
+
+    def _pcore_init_hash
+      { 'results' => @results }
+    end
+
     def iterator
       if Object.const_defined?(:Puppet) && Puppet.const_defined?(:Pops) &&
          self.class.included_modules.include?(Puppet::Pops::Types::Iterable)

--- a/lib/bolt/target.rb
+++ b/lib/bolt/target.rb
@@ -20,6 +20,7 @@ module Bolt
     # rubocop:disable Lint/UnusedMethodArgument
     def self.from_asserted_args(uri = nil,
                                 name = nil,
+                                safe_name = nil,
                                 target_alias = nil,
                                 config = nil,
                                 facts = nil,

--- a/spec/bolt/applicator_spec.rb
+++ b/spec/bolt/applicator_spec.rb
@@ -174,12 +174,12 @@ describe Bolt::Applicator do
 
       expect {
         applicator.apply([targets], :body, scope)
-      }.to raise_error(Bolt::ApplyFailure, <<-MSG.chomp)
-Resources failed to apply for node1
-  File[/tmp/does/not/exist]: It failed.
-Resources failed to apply for node2
-  File[C:/does/not/exist]: It failed.
-MSG
+      }.to raise_error(Bolt::ApplyFailure, <<~MSG.chomp)
+        Resources failed to apply for node1
+          File[/tmp/does/not/exist]: It failed.
+        Resources failed to apply for node2
+          File[C:/does/not/exist]: It failed.
+      MSG
     end
 
     it "only creates 2 threads" do
@@ -213,6 +213,192 @@ MSG
       expect(promises.count).to eq(2)
       promises.each(&:execute)
       t.join
+    end
+  end
+
+  context "with future true" do
+    let(:input) {
+      {
+        code_ast: ast,
+        modulepath: modulepath,
+        pdb_config: config.to_hash,
+        hiera_config: nil,
+        future: true
+      }
+    }
+
+    let(:target_hash) {
+      {
+        target: {
+          name: uri,
+          facts: { 'bolt' => true },
+          vars: {},
+          trusted: {
+            authenticated: 'local',
+            certname: uri,
+            extensions: {},
+            hostname: uri,
+            domain: nil,
+            external: {}
+          }
+        }
+      }
+    }
+
+    before(:each) do
+      # rubocop:disable Style/GlobalVars
+      $future = true
+      # rubocop:enable Style/GlobalVars
+    end
+
+    after(:each) do
+      # rubocop:disable Style/GlobalVars
+      $future = nil
+      # rubocop:enable Style/GlobalVars
+    end
+
+    it 'instantiates' do
+      expect(applicator).to be
+    end
+
+    it 'passes catalog input' do
+      expect(Open3).to receive(:capture3)
+        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.merge(target_hash).to_json)
+        .and_return(['{}', '', double(:status, success?: true)])
+      expect(applicator.future_compile(target, input)).to eq({})
+    end
+
+    it 'logs messages returned on stderr' do
+      logs = [
+        { debug: 'A message' },
+        { notice: 'Stuff happened' }
+      ]
+
+      expect(Open3).to receive(:capture3)
+        .with('ruby', /bolt_catalog/, 'compile', stdin_data: input.merge(target_hash).to_json)
+        .and_return(['{}', logs.map(&:to_json).join("\n"), double(:status, success?: true)])
+      expect(applicator.future_compile(target, input)).to eq({})
+      expect(@log_output.readlines).to eq(
+        [
+          " DEBUG  Bolt::Executor : Started with 1 max thread(s)\n",
+          " DEBUG  Bolt::Applicator : #{target.uri}: A message\n",
+          "NOTICE  Bolt::Applicator : #{target.uri}: Stuff happened\n"
+        ]
+      )
+    end
+
+    context 'with Puppet mocked' do
+      let(:loaders) { double('loaders') }
+      let(:env_loader) { double('env_loader') }
+      before(:each) do
+        env = Puppet::Node::Environment.create(:testing, modulepath)
+        allow(Puppet).to receive(:lookup).with(:current_environment).and_return(env)
+        allow(scope).to receive(:to_hash).and_return({})
+        allow(Puppet).to receive(:lookup).with(:pal_script_compiler).and_return(double(:script_compiler, type: nil))
+        allow(Puppet).to receive(:lookup).with(:loaders).and_return(loaders)
+        allow(loaders).to receive(:private_environment_loader).and_return(env_loader)
+        allow(env_loader).to receive(:load).with(:type, 'result').and_return(double('result'))
+        allow(env_loader).to receive(:load).with(:type, 'resultset').and_return(double('resultset'))
+        allow(env_loader).to receive(:load).with(:type, 'applyresult').and_return(double('applyresult'))
+        allow(Puppet::Pal).to receive(:assert_type)
+        allow(Puppet::Pops::Serialization::ToDataConverter).to receive(:convert).and_return(ast)
+        allow(applicator).to receive(:count_statements)
+      end
+
+      let(:scope) { double('scope') }
+
+      it 'replaces failures to find Puppet' do
+        expect(applicator).to receive(:future_compile).and_return(ast)
+        result = Bolt::Result.new(target, value: report)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(result)
+
+        expect(Bolt::ApplyResult).to receive(:puppet_missing_error).with(result).and_return(nil)
+
+        applicator.apply([target], :body, scope)
+      end
+
+      it 'captures compile errors in a result set' do
+        expect(applicator).to receive(:future_compile).and_raise('Something weird happened')
+
+        resultset = applicator.apply([uri, '_catch_errors' => true], :body, scope)
+        expect(resultset).to be_a(Bolt::ResultSet)
+        expect(resultset).not_to be_ok
+        expect(resultset.count).to eq(1)
+        expect(resultset.first).not_to be_ok
+        expect(resultset.first.error_hash['msg']).to eq('Something weird happened')
+      end
+
+      it 'fails if the report signals failure' do
+        expect(applicator).to receive(:future_compile).and_return(ast)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(
+          Bolt::Result.new(target, value: report.merge('status' => 'failed'))
+        )
+
+        resultset = applicator.apply([target, '_catch_errors' => true], :body, scope)
+        expect(resultset).to be_a(Bolt::ResultSet)
+        expect(resultset).not_to be_ok
+        expect(resultset.count).to eq(1)
+        expect(resultset.first).not_to be_ok
+        expect(resultset.first.error_hash['msg']).to match(/Resources failed to apply for #{uri}/)
+      end
+
+      it 'includes failed resource events for all failing nodes when errored' do
+        resources = {
+          '/tmp/does/not/exist' => [{ 'status' => 'failure', 'message' => 'It failed.' }],
+          'C:/does/not/exist' => [{ 'status' => 'failure', 'message' => 'It failed.' }],
+          '/tmp/sure' => []
+        }.map { |name, events| { "File[#{name}]" => { 'failed' => !events.empty?, 'events' => events } } }
+
+        targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
+        results = targets.zip(resources, %w[failed failed success]).map do |target, res, status|
+          Bolt::Result.new(target, value: { 'status' => status, 'resource_statuses' => res, 'metrics' => {} })
+        end
+
+        allow(applicator).to receive(:future_compile).and_return(ast)
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task).and_return(*results)
+
+        expect {
+          applicator.apply([targets], :body, scope)
+        }.to raise_error(Bolt::ApplyFailure, <<~MSG.chomp)
+          Resources failed to apply for node1
+            File[/tmp/does/not/exist]: It failed.
+          Resources failed to apply for node2
+            File[C:/does/not/exist]: It failed.
+        MSG
+      end
+
+      it "only creates 2 threads" do
+        running = Concurrent::AtomicFixnum.new
+        promises = Concurrent::Array.new
+        allow(applicator).to receive(:future_compile) do
+          count = running.increment
+          if count <= 2
+            # Only first two will block, simplifying cleanup at the end
+            delay = Concurrent::Promise.new { ast }
+            promises << delay
+            delay.value
+          else
+            ast
+          end
+        end
+
+        targets = [Bolt::Target.new('node1'), Bolt::Target.new('node2'), Bolt::Target.new('node3')]
+        allow_any_instance_of(Bolt::Transport::SSH).to receive(:batch_task) do |_, batch|
+          Bolt::Result.new(batch.first, value: report)
+        end
+
+        t = Thread.new {
+          applicator.apply([targets], :body, scope)
+        }
+        sleep(0.2)
+
+        expect(running.value).to eq(2)
+
+        # execute all the promises to release the threads
+        expect(promises.count).to eq(2)
+        promises.each(&:execute)
+        t.join
+      end
     end
   end
 end

--- a/spec/bolt/catalog_spec.rb
+++ b/spec/bolt/catalog_spec.rb
@@ -23,14 +23,14 @@ describe Bolt::Catalog do
   let(:catalog) { Bolt::Catalog.new('warning') }
   let(:notify) { "notify { \"trusted ${trusted}\": }" }
   let(:files) {
-    <<-CODE
-file { '/root/test/':
-  ensure => directory,
-} -> file { '/root/test/hello.txt':
-  ensure  => file,
-  content => "hi there I'm ${$facts['os']['family']}\n"
-}
-CODE
+    <<~CODE
+      file { '/root/test/':
+        ensure => directory,
+      } -> file { '/root/test/hello.txt':
+        ensure  => file,
+        content => "hi there I'm ${$facts['os']['family']}\n"
+      }
+    CODE
   }
 
   let(:plan) { File.join(__FILE__, '../../fixtures/apply/basic/plans/trusted.pp') }

--- a/spec/bolt/cli_spec.rb
+++ b/spec/bolt/cli_spec.rb
@@ -241,8 +241,8 @@ describe "Bolt::CLI" do
 
       it "reads from stdin when --targets is '-'" do
         nodes = <<~'NODES'
-         foo
-         bar
+          foo
+          bar
         NODES
         cli = Bolt::CLI.new(%w[command run uptime --targets -])
         allow(STDIN).to receive(:read).and_return(nodes)

--- a/spec/bolt/outputter/human_spec.rb
+++ b/spec/bolt/outputter/human_spec.rb
@@ -85,9 +85,9 @@ describe "Bolt::Outputter::Human" do
 
   it "formats a table" do
     outputter.print_table([%w[a b], %w[c1 d]])
-    expect(output.string).to eq(<<-TABLE)
-a    b
-c1   d
+    expect(output.string).to eq(<<~TABLE)
+      a    b
+      c1   d
     TABLE
   end
 
@@ -109,19 +109,19 @@ c1   d
       }
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-cinnamon_roll - A delicious sweet bun
+      cinnamon_roll - A delicious sweet bun
 
-USAGE:
-bolt task run --targets <node-name> cinnamon_roll icing=<value>
+      USAGE:
+      bolt task run --targets <node-name> cinnamon_roll icing=<value>
 
-PARAMETERS:
-- icing: Cream cheese
-    Rich, tangy, sweet
+      PARAMETERS:
+      - icing: Cream cheese
+          Rich, tangy, sweet
 
-MODULE:
-/path/to/cinnamony/goodness
+      MODULE:
+      /path/to/cinnamony/goodness
     TASK_OUTPUT
   end
 
@@ -147,21 +147,21 @@ MODULE:
       }
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-sticky_bun - A delicious sweet bun with nuts
+      sticky_bun - A delicious sweet bun with nuts
 
-USAGE:
-bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
+      USAGE:
+      bolt task run --targets <node-name> sticky_bun glaze=<value> pecans=<value>
 
-PARAMETERS:
-- glaze: Sticky
-    Sweet
-- pecans: Data
-    The best kind of nut
+      PARAMETERS:
+      - glaze: Sticky
+          Sweet
+      - pecans: Data
+          The best kind of nut
 
-MODULE:
-/this/test/is/making/me/hungry
+      MODULE:
+      /this/test/is/making/me/hungry
     TASK_OUTPUT
   end
 
@@ -173,15 +173,15 @@ MODULE:
       'metadata' => {}
     }
     outputter.print_task_info(task)
-    expect(output.string).to eq(<<-TASK_OUTPUT)
+    expect(output.string).to eq(<<~TASK_OUTPUT)
 
-monkey_bread
+      monkey_bread
 
-USAGE:
-bolt task run --targets <node-name> monkey_bread
+      USAGE:
+      bolt task run --targets <node-name> monkey_bread
 
-MODULE:
-built-in module
+      MODULE:
+      built-in module
     TASK_OUTPUT
   end
 
@@ -211,19 +211,19 @@ built-in module
       }
     }
     outputter.print_plan_info(plan)
-    expect(output.string).to eq(<<-PLAN_OUTPUT)
+    expect(output.string).to eq(<<~PLAN_OUTPUT)
 
-planity_plan
+      planity_plan
 
-USAGE:
-bolt plan run planity_plan foo=<value> [baz=<value>]
+      USAGE:
+      bolt plan run planity_plan foo=<value> [baz=<value>]
 
-PARAMETERS:
-- foo: Bar
-- baz: Bar
+      PARAMETERS:
+      - foo: Bar
+      - baz: Bar
 
-MODULE:
-plans/plans/plans/plans
+      MODULE:
+      plans/plans/plans/plans
     PLAN_OUTPUT
   end
 

--- a/spec/fixtures/apply/puppet_types/plans/applyresult.pp
+++ b/spec/fixtures/apply/puppet_types/plans/applyresult.pp
@@ -1,0 +1,17 @@
+plan puppet_types::applyresult (
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+  run_command('rm -rf /home/bolt/tmp', $first)
+
+  $result = apply($first) {
+    file { '/home/bolt/tmp':
+      ensure  => file,
+    }
+  }.first
+
+  return apply($first) {
+    notify { "ApplyResult resource: ${$result.report['resource_statuses']}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/error.pp
+++ b/spec/fixtures/apply/puppet_types/plans/error.pp
@@ -1,0 +1,11 @@
+plan puppet_types::error(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  $error = run_command("not real", $targets, _catch_errors => true)
+  return apply($first) {
+    notify { "ApplyResult resource: ${$error[0].error.message}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/get_target.pp
+++ b/spec/fixtures/apply/puppet_types/plans/get_target.pp
@@ -1,0 +1,11 @@
+plan puppet_types::get_target(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $name = get_target($targets).name
+    notify { $name: }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/get_targets.pp
+++ b/spec/fixtures/apply/puppet_types/plans/get_targets.pp
@@ -1,0 +1,13 @@
+plan puppet_types::get_targets(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $names = get_targets($targets).map |$t| {
+      $t.name
+    }
+    notify { $names.join(","): }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/result.pp
+++ b/spec/fixtures/apply/puppet_types/plans/result.pp
@@ -1,0 +1,13 @@
+plan puppet_types::result (
+  TargetSpec $targets
+) {
+  $target = get_target($targets)
+  $target.apply_prep
+
+  $result = run_command('whoami', $target).first
+
+  return apply($target) {
+    notify { "Result value: ${$result.value['stdout']}": }
+    notify { "Result target name: ${$result.target.name}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/resultset.pp
+++ b/spec/fixtures/apply/puppet_types/plans/resultset.pp
@@ -1,0 +1,12 @@
+plan puppet_types::resultset (
+  TargetSpec $targets
+) {
+  $first = get_targets($targets)[0]
+  $first.apply_prep
+
+  $result = run_command('whoami', $targets)
+
+  return apply($first) {
+    notify { "ResultSet target names: ${$result.names}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/target.pp
+++ b/spec/fixtures/apply/puppet_types/plans/target.pp
@@ -1,0 +1,10 @@
+plan puppet_types::target (
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    notify { "ApplyTarget protocol: ${$first.protocol}": }
+  }
+}

--- a/spec/fixtures/apply/puppet_types/plans/target_new.pp
+++ b/spec/fixtures/apply/puppet_types/plans/target_new.pp
@@ -1,0 +1,10 @@
+plan puppet_types::target_new(
+  TargetSpec $targets
+) {
+  $first = get_target($targets)
+  $first.apply_prep
+
+  return apply($first) {
+    $t = Target.new('localhost')
+  }
+}

--- a/spec/integration/apply_compile_spec.rb
+++ b/spec/integration/apply_compile_spec.rb
@@ -27,10 +27,11 @@ describe "passes parsed AST to the apply_catalog task" do
     }
   end
 
-  def get_notifies(result)
+  def get_notifies(result, future = false)
     expect(result).not_to include('kind')
     expect(result[0]).to include('status' => 'success')
-    result[0]['result']['report']['catalog']['resources'].select { |r| r['type'] == 'Notify' }
+    key = future ? 'value' : 'result'
+    result[0][key]['report']['catalog']['resources'].select { |r| r['type'] == 'Notify' }
   end
 
   # SSH only required to simplify capturing stdin passed to the task. WinRM omitted as slower and unnecessary.
@@ -265,8 +266,8 @@ describe "passes parsed AST to the apply_catalog task" do
           expect(notify[1]['title']).to eq("Target 1 Facts: {operatingsystem => Ubuntu, added => fact}")
           expect(notify[2]['title']).to eq("Target 1 Vars: {environment => production, features => [puppet-agent]}")
           res = "Target 0 Config: {connect-timeout => 11, " \
-                "tty => false, load-config => true, disconnect-timeout => 5, password => bolt, " \
-                "host-key-check => false}"
+            "tty => false, load-config => true, disconnect-timeout => 5, password => bolt, " \
+            "host-key-check => false}"
           expect(notify[3]['title']).to eq(res)
           expect(notify[4]['title']).to eq("Target 1 Password: secret")
         end
@@ -302,6 +303,75 @@ describe "passes parsed AST to the apply_catalog task" do
           notify = get_notifies(result)
           expect(notify[0]['title']).to eq("Num Targets: 0")
           expect(notify[1]['title']).to eq("Target Name: foo")
+        end
+      end
+    end
+
+    context 'with Bolt plan datatypes' do
+      let(:config) { File.join(__dir__, '../fixtures/configs/future.yml') }
+      let(:inventory) { File.join(__dir__, '../fixtures/apply/inventory_2.yaml') }
+      let(:tflags) { %W[--no-host-key-check --configfile #{config} --inventoryfile #{inventory}] }
+
+      it 'serializes ResultSet objects in apply blocks' do
+        result = run_cli_json(%w[plan run puppet_types::resultset] + config_flags)
+        notify = get_notifies(result, true)
+        expect(notify[0]['title']).to eq("ResultSet target names: [ssh://bolt@localhost:20022]")
+      end
+
+      it 'serializes Result objects in apply blocks' do
+        result = run_cli_json(%w[plan run puppet_types::result] + config_flags)
+        notify = get_notifies(result, true)
+        expect(notify[0]['title']).to eq("Result value: bolt\n")
+        expect(notify[1]['title']).to eq("Result target name: ssh://bolt@localhost:20022")
+      end
+
+      it 'serializes ApplyResult objects in apply blocks' do
+        result = run_cli_json(%w[plan run puppet_types::applyresult] + config_flags)
+        notify = get_notifies(result, true)
+        expect(notify[0]['title']).to eq("ApplyResult resource: [File[/tmp/applyresult/]]")
+      end
+
+      it 'serializes Target objects as ApplyTargets in apply blocks' do
+        result = run_cli_json(%w[plan run puppet_types::target] + config_flags)
+        notify = get_notifies(result, true)
+        expect(notify[0]['title']).to eq("ApplyTarget protocol: ssh")
+      end
+
+      it 'serializes Error objects in apply blocks' do
+        result = run_cli_json(%w[plan run puppet_types::error] + config_flags)
+        notify = get_notifies(result, true)
+        expect(notify[0]['title']).to eq("ApplyResult resource: The command failed with exit code 127")
+      end
+
+      context 'when calling invalid functions in apply' do
+        it 'errors when get_targets is called' do
+          result = run_cli_json(%w[plan run puppet_types::get_targets] + config_flags)
+          expect(result['kind']).to eq('bolt/apply-failure')
+          error = result['details']['result_set'][0]['value']['_error']
+          expect(error['kind']).to eq('bolt/apply-error')
+          expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+          expect(@log_output.readlines)
+            .to include(/Plan language function 'get_targets' cannot be used from declarative manifest code/)
+        end
+
+        it 'errors when get_target is called' do
+          result = run_cli_json(%w[plan run puppet_types::get_target] + config_flags)
+          expect(result['kind']).to eq('bolt/apply-failure')
+          error = result['details']['result_set'][0]['value']['_error']
+          expect(error['kind']).to eq('bolt/apply-error')
+          expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+          expect(@log_output.readlines)
+            .to include(/Plan language function 'get_target' cannot be used from declarative manifest code/)
+        end
+
+        it 'errors when Target.new is called' do
+          result = run_cli_json(%w[plan run puppet_types::target_new] + config_flags)
+          expect(result['kind']).to eq('bolt/apply-failure')
+          error = result['details']['result_set'][0]['value']['_error']
+          expect(error['kind']).to eq('bolt/apply-error')
+          expect(error['msg']).to match(/Apply failed to compile for #{uri}/)
+          expect(@log_output.readlines)
+            .to include(/Target objects cannot be instantiated inside apply blocks/)
         end
       end
     end


### PR DESCRIPTION
There are 4 custom types in the Bolt plan language that we want to make
available inside apply blocks: Target, Result, ResultSet, ApplyResult.
For each of the *Result* objects this is accomplished by serializing the
plan variables to the apply block as pcore instead of as json. We also
needed to add pcore_init methods to the implementation classes of the
objects, because the pcore deserializer will by default call
`initialize` on the class and pass in the values of the attributes of
the type, which doesn't match the signature of the actual
implementations. Using `_pcore_init_hash` and `_pcore_init_from_hash`
lets us define what data gets serialized and how it gets deserialized
for those types.

Target objects are trickier for a few reasons:
1. They must have an associate inventory
2. ...

Stil TODO:
- [x] Future proof
- [ ] Tests
- [ ] Docs
- [x] Threading